### PR TITLE
DWI::Shells: bzero_threshold no longer a global variable

### DIFF
--- a/src/dwi/shells.cpp
+++ b/src/dwi/shells.cpp
@@ -1,7 +1,6 @@
 
 #include "dwi/shells.h"
 
-#include "file/config.h"
 
 
 namespace MR
@@ -22,8 +21,6 @@ namespace MR
         + Argument ("list").type_sequence_float();
 
 
-
-    const float bzero_threshold = File::Config::get_float ("BZeroThreshold", 10.0);
 
 
 
@@ -76,7 +73,7 @@ namespace MR
             throw Exception ("Cannot select shells corresponding to negative b-values");
 
           // Automatically select a b=0 shell if the requested b-value is zero
-          if (*b <= bzero_threshold) {
+          if (*b <= bzero_threshold()) {
 
             if (smallest().is_bzero()) {
               to_retain[0] = true;
@@ -254,7 +251,7 @@ namespace MR
           std::vector<size_t> neighborIdx;
           regionQuery (bvals, b, neighborIdx);
 
-          if (b > bzero_threshold && neighborIdx.size() < DWI_SHELLS_MIN_LINKAGE) {
+          if (b > bzero_threshold() && neighborIdx.size() < DWI_SHELLS_MIN_LINKAGE) {
 
             clusters[ii] = 0;
 

--- a/src/dwi/shells.h
+++ b/src/dwi/shells.h
@@ -34,6 +34,7 @@
 #include "math/matrix.h"
 #include "math/vector.h"
 
+#include "file/config.h"
 
 
 // Don't expect these values to change depending on the particular command that is initialising the Shells class;
@@ -67,8 +68,11 @@ namespace MR
 
     extern const App::OptionGroup ShellOption;
 
+    inline float bzero_threshold () {
+      static const float value = File::Config::get_float ("BZeroThreshold", 10.0);
+      return value;
+    }
 
-    extern const float bzero_threshold;
 
 
     class Shell
@@ -99,7 +103,7 @@ namespace MR
         float get_min()   const { return min; }
         float get_max()   const { return max; }
 
-        bool is_bzero()   const { return (mean < bzero_threshold); }
+        bool is_bzero()   const { return (mean < bzero_threshold()); }
 
 
         bool operator< (const Shell& rhs) const { return (mean < rhs.mean); }


### PR DESCRIPTION
The bzero_threshold variable used in the DWI::Shells class was declared as a global variable, and initialised from File::Config. Problem is that initialisation for a global variable happens before entering main(), and hence before Config::init() (in App::parse()). So there is no way that the Config::get() call could return anything other than the default supplied, since the Config would appear empty at that point...

Solution proposed here is to  return a static member variable in a function, which defers initialisation until the first time it's called. Hopefully that function will never be called before Config::init()...